### PR TITLE
doc: missing docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,6 @@ bitbybit = "1.3.3"
 uom = { version = "0.37.0",default-features = false, features = ["autoconvert", "si", "f32",]}
 visibility = "0.1.1"
 
-
-[package.metadata.docs.rs]
-no-default-features = false   
-all-features = false            
-# no need to set features here because default already includes sync
-# This is to ensures the docs build correctly on crates.io.
-
 [dev-dependencies]
 utils ={ path = "./utils"}
 


### PR DESCRIPTION
# Description

The docs for v0.1.0 seem to be completely missing on crates.io and docs.rs. I feel this PR should fix that

## Type of change

Please Tick the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Cant be tested until its run

