### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable -->
-<!-- markdown-link-check-disable -->
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -8,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.3](https://github.com/ScottGibb/AP33772S-rs/compare/ap33772s-rs-v0.1.2...ap33772s-rs-v0.1.3) - 2025-08-21
+
+### Added
+
+- *(workflows)* Add comprehensive GitHub Copilot instructions for AP33772S-rs development ([#51](https://github.com/ScottGibb/AP33772S-rs/pull/51))
+
+### Fixed
+
+- *(imports)* Added missing error type export
+- *(imports)* Removed reexport of units
+- *(imports)* Fixed embedded_hal_async dep
+
+### Other
+
+- *(docs.rs)* Fixed all docs so that they now are tested with cargo test
+- *(docs.rs)* Fixed Synchronous Example
+- *(docs.rs)* added active development
+- add docs clarification
+- Complete API documentation with working examples and tests
+- Complete comprehensive documentation for getter and setter methods
+- Enhance documentation for lib.rs, types.rs, units.rs, and ap33772s.rs
+- *(imports)* Fixed the units import on startup configuration
+- Refactored units into its own module
+- Apply suggestion from @Copilot
+- *(docs.rs)* :sparkles: Added some more documentation
+- *(docs.rs)* Added More documentation surrounding exported types
+<!-- markdownlint-disable -->
+<!-- markdown-link-check-disable -->
 
 ## [0.1.2](https://github.com/ScottGibb/AP33772S-rs/compare/ap33772s-rs-v0.1.1...ap33772s-rs-v0.1.2) - 2025-08-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ap33772s-rs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arbitrary-int",
  "bitbybit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ap33772s-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Driver for the AP33772S USB C Power Delivery and Extended Power Supply IC. Allowing for both embedded-hal and embedded-hal-async I2C"
 authors = ["Scott Gibb <smgibb@yahoo.com>"]


### PR DESCRIPTION



## 🤖 New release

* `ap33772s-rs`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/ScottGibb/AP33772S-rs/compare/ap33772s-rs-v0.1.2...ap33772s-rs-v0.1.3) - 2025-08-21

### Added

- *(workflows)* Add comprehensive GitHub Copilot instructions for AP33772S-rs development ([#51](https://github.com/ScottGibb/AP33772S-rs/pull/51))

### Fixed

- *(imports)* Added missing error type export
- *(imports)* Removed reexport of units
- *(imports)* Fixed embedded_hal_async dep

### Other

- *(docs.rs)* Fixed all docs so that they now are tested with cargo test
- *(docs.rs)* Fixed Synchronous Example
- *(docs.rs)* added active development
- add docs clarification
- Complete API documentation with working examples and tests
- Complete comprehensive documentation for getter and setter methods
- Enhance documentation for lib.rs, types.rs, units.rs, and ap33772s.rs
- *(imports)* Fixed the units import on startup configuration
- Refactored units into its own module
- Apply suggestion from @Copilot
- *(docs.rs)* :sparkles: Added some more documentation
- *(docs.rs)* Added More documentation surrounding exported types
<!-- markdownlint-disable -->
<!-- markdown-link-check-disable -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).