### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/ScottGibb/AP33772S-rs/compare/ap33772s-rs-v0.1.3...ap33772s-rs-v0.1.4) - 2025-11-25
+
+### Added
+
+- *(versioning)* Update cargo.toml
+
+### Fixed
+
+- *(versioning)* Fixed the cargo lock file issues
+- *(deps)* bump arbitrary-int from 1.3.0 to 2.0.0 ([#60](https://github.com/ScottGibb/AP33772S-rs/pull/60))
+- *(deps)* bump bitbybit from 1.3.3 to 1.4.0 ([#64](https://github.com/ScottGibb/AP33772S-rs/pull/64))
+- *(deps)* bump bitbybit from 1.3.3 to 1.4.0 in /examples/raspberrypi ([#66](https://github.com/ScottGibb/AP33772S-rs/pull/66))
+
+### Other
+
+- Merge branch 'main' into dependabot/github_actions/actions/checkout-6
+- *(deps)* bump actions/upload-artifact from 4 to 5 ([#71](https://github.com/ScottGibb/AP33772S-rs/pull/71))
+- *(deps)* bump oxsecurity/megalinter from 8 to 9 ([#67](https://github.com/ScottGibb/AP33772S-rs/pull/67))
+- *(deps)* bump actions/checkout from 4 to 5 ([#58](https://github.com/ScottGibb/AP33772S-rs/pull/58))
+
 ## [0.1.3](https://github.com/ScottGibb/AP33772S-rs/compare/ap33772s-rs-v0.1.2...ap33772s-rs-v0.1.3) - 2025-08-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ap33772s-rs"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "Driver for the AP33772S USB C Power Delivery and Extended Power Supply IC. Allowing for both embedded-hal and embedded-hal-async I2C"
 authors = ["Scott Gibb <smgibb@yahoo.com>"]


### PR DESCRIPTION



## 🤖 New release

* `ap33772s-rs`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/ScottGibb/AP33772S-rs/compare/ap33772s-rs-v0.1.3...ap33772s-rs-v0.1.4) - 2025-11-25

### Added

- *(versioning)* Update cargo.toml

### Fixed

- *(versioning)* Fixed the cargo lock file issues
- *(deps)* bump arbitrary-int from 1.3.0 to 2.0.0 ([#60](https://github.com/ScottGibb/AP33772S-rs/pull/60))
- *(deps)* bump bitbybit from 1.3.3 to 1.4.0 ([#64](https://github.com/ScottGibb/AP33772S-rs/pull/64))
- *(deps)* bump bitbybit from 1.3.3 to 1.4.0 in /examples/raspberrypi ([#66](https://github.com/ScottGibb/AP33772S-rs/pull/66))

### Other

- Merge branch 'main' into dependabot/github_actions/actions/checkout-6
- *(deps)* bump actions/upload-artifact from 4 to 5 ([#71](https://github.com/ScottGibb/AP33772S-rs/pull/71))
- *(deps)* bump oxsecurity/megalinter from 8 to 9 ([#67](https://github.com/ScottGibb/AP33772S-rs/pull/67))
- *(deps)* bump actions/checkout from 4 to 5 ([#58](https://github.com/ScottGibb/AP33772S-rs/pull/58))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).